### PR TITLE
Translation fails by not picking up the correct .mo

### DIFF
--- a/public/class-local-pickup-time.php
+++ b/public/class-local-pickup-time.php
@@ -34,7 +34,7 @@ class Local_Pickup_Time {
 	 *
 	 * @var      string
 	 */
-	protected $plugin_slug = 'woocommerce-local-plugin-time';
+	protected $plugin_slug = 'woocommerce-local-pickup-time';
 
 	/**
 	 * Instance of this class.


### PR DESCRIPTION
Just a typo :) the slug needs to be exactly the same as the plugin name.