### PR TITLE
Removes Closed Days from Pickup List

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ branches:
   only:
     - master
     - /^feature\/.*$/
+    - /^fix\/.*$/
 
 # Git clone depth
 # By default Travis CI clones repositories to a depth of 50 commits

--- a/public/class-local-pickup-time.php
+++ b/public/class-local-pickup-time.php
@@ -420,12 +420,14 @@ class Local_Pickup_Time {
 			$pickup_day_name_lower = strtolower( $pickup_day_name );
 
 			// Get the day's opening and closing times.
-			$pickup_day_open_time  = get_option( 'local_pickup_hours_' . $pickup_day_name_lower . '_start', '10:00' );
-			$pickup_day_open_time  = empty( $pickup_day_open_time ) ? '10:00' : $pickup_day_open_time;
-			$pickup_day_close_time = get_option( 'local_pickup_hours_' . $pickup_day_name_lower . '_end', '19:00' );
-			$pickup_day_close_time = empty( $pickup_day_close_time ) ? '19:00' : $pickup_day_close_time;
+			$pickup_day_open_time  = get_option( 'local_pickup_hours_' . $pickup_day_name_lower . '_start', '' );
+			$pickup_day_close_time = get_option( 'local_pickup_hours_' . $pickup_day_name_lower . '_end', '' );
 
-			if ( ! in_array( $pickup_datetime->format( 'm/d/Y' ), $dates_closed ) ) {
+			if (
+				! in_array( $pickup_datetime->format( 'm/d/Y' ), $dates_closed ) &&
+				! empty( $pickup_day_open_time ) &&
+				! empty( $pickup_day_close_time )
+			) {
 
 				// Get the intervals for the day and merge the results with the previous array of intervals.
 				$pickup_options = array_replace(


### PR DESCRIPTION
Fixes #33 - Removes defaulting the open start time/end time, adds check for empty start/end time and excludes the day considering it as closed and not available for pickup.