### PR TITLE
* Changes direct WC_Order id attribute access to use get_id() method.

### DIFF
--- a/admin/class-local-pickup-time-admin.php
+++ b/admin/class-local-pickup-time-admin.php
@@ -330,7 +330,7 @@ class Local_Pickup_Time_Admin {
 	 * @param object $order  The order object.
 	 */
 	public function show_metabox( $order ) {
-		$order_meta = get_post_custom( $order->id );
+		$order_meta = get_post_custom( $order->get_id() );
 
 		echo '<p><strong>' . __( 'Pickup Time:', 'woocommerce-local-pickup-time' ) . '</strong> ' . $this->pickup_time_select_translatable( $order_meta[ $this->order_meta_key ][0] ) . '</p>';
 

--- a/public/class-local-pickup-time.php
+++ b/public/class-local-pickup-time.php
@@ -581,7 +581,7 @@ class Local_Pickup_Time {
 	 */
 	public function update_order_email_fields( $fields, $sent_to_admin, $order ) {
 
-		$value              = $this->pickup_time_select_translatable( get_post_meta( $order->id, $this->order_meta_key, true ) );
+		$value              = $this->pickup_time_select_translatable( get_post_meta( $order->get_id(), $this->order_meta_key, true ) );
 		$fields['meta_key'] = array(
 			'label' => __( 'Pickup Time', 'woocommerce-local-pickup-time' ),
 			'value' => $value,


### PR DESCRIPTION
Fixes #43 and aligns code calls for order is to WooCommerce best practices.