### PR TITLE
Added 3 filters

### DIFF
--- a/public/class-local-pickup-time.php
+++ b/public/class-local-pickup-time.php
@@ -553,7 +553,7 @@ class Local_Pickup_Time {
 				'type'     => 'select',
 				'class'    => array( 'local-pickup-time-select-field form-row-wide' ),
 				'label'    => __( 'Pickup Time', 'woocommerce-local-pickup-time' ),
-				'required' => true,
+				'required' => apply_filters('woocommerce_local_pickup_time_checkout_select_required', true ),
 				'options'  => $this->build_pickup_time_options(),
 			),
 			$checkout->get_value( 'local_pickup_time_select' )

--- a/public/class-local-pickup-time.php
+++ b/public/class-local-pickup-time.php
@@ -540,7 +540,12 @@ class Local_Pickup_Time {
 	 * @param object $checkout The checkout object.
 	 */
 	public function time_select( $checkout ) {
-		echo '<div id="local-pickup-time-select"><h2>' . __( 'Pickup Time', 'woocommerce-local-pickup-time' ) . '</h2>';
+            
+            $show_field = apply_filters('woocommerce_local_pickup_time_checkout_selected', true );
+            
+            if($show_field == true) {
+                
+            	echo '<div id="local-pickup-time-select"><h2>' . __( 'Pickup Time', 'woocommerce-local-pickup-time' ) . '</h2>';
 
 		woocommerce_form_field(
 			'local_pickup_time_select',
@@ -555,6 +560,7 @@ class Local_Pickup_Time {
 		);
 
 		echo '</div>';
+            }
 	}
 
 	/**
@@ -563,13 +569,17 @@ class Local_Pickup_Time {
 	 * @since    1.3.0
 	 */
 	public function field_process() {
+             $show_field = apply_filters('woocommerce_local_pickup_time_field_process', true );
+            
+            if($show_field == true){
+                           
 		global $woocommerce;
 
 		// Check if set, if its not set add an error.
 		if ( ! $_POST['local_pickup_time_select'] ) {
 			wc_add_notice( __( 'Please select a pickup time.', 'woocommerce-local-pickup-time' ), 'error' );
 		}
-
+            }
 	}
 
 	/**
@@ -596,12 +606,17 @@ class Local_Pickup_Time {
 	 * @return array    The array of order email fields including the pickup time field.
 	 */
 	public function update_order_email_fields( $fields, $sent_to_admin, $order ) {
+            
+            $show_field = apply_filters('woocommerce_local_pickup_time_update_order_email_fields', true, $order );
+            
+            if($show_field == true){
 
 		$value              = $this->pickup_time_select_translatable( get_post_meta( $order->get_id(), $this->order_meta_key, true ) );
 		$fields['meta_key'] = array(
 			'label' => __( 'Pickup Time', 'woocommerce-local-pickup-time' ),
 			'value' => $value,
 		);
+            }
 
 		return $fields;
 	}

--- a/public/class-local-pickup-time.php
+++ b/public/class-local-pickup-time.php
@@ -590,8 +590,11 @@ class Local_Pickup_Time {
 	 * @param integer $order_id The ID of the order you want meta data for.
 	 */
 	public function update_order_meta( $order_id ) {
-		if ( $_POST['local_pickup_time_select'] ) {
-			update_post_meta( $order_id, $this->order_meta_key, esc_attr( $_POST['local_pickup_time_select'] ) );
+		$show_field = apply_filters('woocommerce_local_pickup_time_update_order_meta', true );
+            	if($show_field == true){
+			if ( $_POST['local_pickup_time_select'] ) {
+				update_post_meta( $order_id, $this->order_meta_key, esc_attr( $_POST['local_pickup_time_select'] ) );
+			}
 		}
 	}
 

--- a/public/class-local-pickup-time.php
+++ b/public/class-local-pickup-time.php
@@ -607,7 +607,7 @@ class Local_Pickup_Time {
 	 */
 	public function update_order_email_fields( $fields, $sent_to_admin, $order ) {
             
-            $show_field = apply_filters('woocommerce_local_pickup_time_update_order_email_fields', true, $order );
+            $show_field = apply_filters('woocommerce_local_pickup_time_update_order_email_fields', true, $order, $fields );
             
             if($show_field == true){
 


### PR DESCRIPTION
Hi guys,

I am working on setting up a online shop for my mother in law's restaurant where we have both local pick and shipping. Hence, I need to control when the local pickup plugin is shown. For this I added three filters that control whether:

-pickup time selection on checkout page is shown
-pickup time is added to email
-pickup time is shown on order summary

Those filters I use in my own plugin to control the logic.

I hope you guys approve the changes.
(This is my first time working with Github. I am not sure whether I did everything right ;). Let me know if there was a handling mistake. The commit should only include the three filters.)

BR
Fabian