### PR TITLE
fix(checkout): Duplicate HTML id attribute on time select output

### DIFF
--- a/public/class-local-pickup-time.php
+++ b/public/class-local-pickup-time.php
@@ -853,7 +853,7 @@ class Local_Pickup_Time {
 			),
 		);
 
-		echo wp_kses( '<div id="' . $this->get_order_post_key() . '">', $allowed_html );
+		echo wp_kses( '<div id="' . $this->get_order_post_key() . '_wrapper">', $allowed_html );
 
 		woocommerce_form_field(
 			$this->get_order_post_key(),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time/blob/master/.github/CONTRIBUTING.md)? 
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time/pulls)) for the same update/change?

### Changes proposed in this Pull Request:

Appends `_wrapper` to the `id` attribute of the `<div>` element of the public view/form. 

Fixes a regression introduced in 1.4.0 where both the `<select>` and the `<div>` elements took the same value `local_pickup_time_select` returned from `get_order_post_key()` .

Prior to 1.4.0, the `<div>` element was identified with this hard-coded value: `local-pickup-time-select` using dashes instead of underscores (https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time/blob/1.3.13/public/class-local-pickup-time.php#L692).

This duplicate html id has caused various issues with custom client-side logic around the local pickup field and comes with accessibility issues (since the `for` attribute of `<label>` element does not link to the field element anymore on some/all (?) browsers).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] ~~Have you written new tests for your changes, as applicable?~~ No public unit tests yet.
* [ ] ~~Have you successfully run tests with your changes locally?~~ No public unit tests yet.


### Changelog entry

- Changed `<div>` wrapper `id` attribute value to `local_pickup_time_select_wrapper`.
- Fixed duplicate html id with `<select>` element.
